### PR TITLE
Add defaultUser option to zsh feature

### DIFF
--- a/src/zsh/README.md
+++ b/src/zsh/README.md
@@ -19,7 +19,7 @@ A feature to install and configure zsh with OhMyZsh
 | plugins | A space separated list of plugins to activate | string | git |
 | setLocale | Install required locales package and set locale | boolean | true |
 | desiredLocale | The locale that should be set when 'setLocale' is true | string | en_US.UTF-8 UTF-8 |
-| defaultUser | Sets the DEFAULT_USER property in .zshrc | string | none |
+| defaultUser | Sets the DEFAULT_USER property in .zshrc | string |  |
 
 ## OS Support
 

--- a/src/zsh/README.md
+++ b/src/zsh/README.md
@@ -19,6 +19,7 @@ A feature to install and configure zsh with OhMyZsh
 | plugins | A space separated list of plugins to activate | string | git |
 | setLocale | Install required locales package and set locale | boolean | true |
 | desiredLocale | The locale that should be set when 'setLocale' is true | string | en_US.UTF-8 UTF-8 |
+| defaultUser | Sets the DEFAULT_USER property in .zshrc | string | none |
 
 ## OS Support
 

--- a/src/zsh/README.md
+++ b/src/zsh/README.md
@@ -19,7 +19,7 @@ A feature to install and configure zsh with OhMyZsh
 | plugins | A space separated list of plugins to activate | string | git |
 | setLocale | Install required locales package and set locale | boolean | true |
 | desiredLocale | The locale that should be set when 'setLocale' is true | string | en_US.UTF-8 UTF-8 |
-| defaultUser | Sets the DEFAULT_USER property in .zshrc | string |  |
+| defaultUser | Sets the DEFAULT_USER property in .zshrc | string | not set |
 
 ## OS Support
 

--- a/src/zsh/devcontainer-feature.json
+++ b/src/zsh/devcontainer-feature.json
@@ -17,7 +17,7 @@
     "defaultUser": {
       "description": "The defaultUser to set in .zshrc",
       "type": "string",
-      "default": "vscode",
+      "default": "",
       "proposals": [
         "vscode",
         "root"

--- a/src/zsh/devcontainer-feature.json
+++ b/src/zsh/devcontainer-feature.json
@@ -14,6 +14,15 @@
         "agnoster"
       ]
     },
+    "defaultUser": {
+      "description": "The defaultUser to set in .zshrc",
+      "type": "string",
+      "default": "vscode",
+      "proposals": [
+        "vscode",
+        "root"
+      ]
+    },
     "plugins": {
       "description": "A space separated list of plugins to activate",
       "type": "string",

--- a/src/zsh/install.sh
+++ b/src/zsh/install.sh
@@ -43,6 +43,9 @@ fi
 # set the theme
 upsert_config_option "^ZSH_THEME=.*$" "ZSH_THEME=\"$THEME\"" "$ZSH_RC_FILE"
 
+# set the default user
+upsert_config_option "^DEFAULT_USER=.*$" "DEFAULT_USER=\"$DEFAULTUSER\"" "$ZSH_RC_FILE"
+
 # configure the plugins
 upsert_config_option "^plugins=\\(.*\\)$" "plugins=($PLUGINS)" "$ZSH_RC_FILE"
 

--- a/src/zsh/install.sh
+++ b/src/zsh/install.sh
@@ -44,7 +44,9 @@ fi
 upsert_config_option "^ZSH_THEME=.*$" "ZSH_THEME=\"$THEME\"" "$ZSH_RC_FILE"
 
 # set the default user
-upsert_config_option "^DEFAULT_USER=.*$" "DEFAULT_USER=\"$DEFAULTUSER\"" "$ZSH_RC_FILE"
+if [[ -n "$DEFAULTUSER" ]]; then
+  upsert_config_option "^DEFAULT_USER=.*$" "DEFAULT_USER=\"$DEFAULTUSER\"" "$ZSH_RC_FILE"
+fi
 
 # configure the plugins
 upsert_config_option "^plugins=\\(.*\\)$" "plugins=($PLUGINS)" "$ZSH_RC_FILE"

--- a/test/zsh/scenarios.json
+++ b/test/zsh/scenarios.json
@@ -15,6 +15,15 @@
       }
     }
   },
+  "using_theme_agnoster_with_default_user": {
+    "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+    "features": {
+      "zsh": {
+        "theme": "agnoster",
+        "defaultUser": "vscode"
+      }
+    }
+  },
   "configuring_plugins_git_and_docker": {
     "image": "mcr.microsoft.com/devcontainers/base:bullseye",
     "features": {

--- a/test/zsh/scenarios.json
+++ b/test/zsh/scenarios.json
@@ -24,6 +24,14 @@
       }
     }
   },
+  "using_theme_agnoster_with_no_default_user": {
+    "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+    "features": {
+      "zsh": {
+        "theme": "agnoster"
+      }
+    }
+  },
   "configuring_plugins_git_and_docker": {
     "image": "mcr.microsoft.com/devcontainers/base:bullseye",
     "features": {

--- a/test/zsh/test_functions.sh
+++ b/test/zsh/test_functions.sh
@@ -36,6 +36,13 @@ assert_configured_theme_is() {
   fi
 }
 
+assert_configured_default_user_is() {
+  theme=$1
+  if ! grep -E -q "^DEFAULT_USER=\"$theme\"" ~/.zshrc; then
+    exit 1
+  fi
+}
+
 assert_configured_plugins() {
   plugins=$1
   if ! grep -E -q "^plugins=\\($plugins\\)" ~/.zshrc; then

--- a/test/zsh/test_functions.sh
+++ b/test/zsh/test_functions.sh
@@ -43,6 +43,12 @@ assert_configured_default_user_is() {
   fi
 }
 
+assert_configured_default_user_is_not_set() {
+  if grep -q "^DEFAULT_USER=" ~/.zshrc; then
+    exit 1
+  fi
+}
+
 assert_configured_plugins() {
   plugins=$1
   if ! grep -E -q "^plugins=\\($plugins\\)" ~/.zshrc; then

--- a/test/zsh/using_theme_agnoster_with_default_user.sh
+++ b/test/zsh/using_theme_agnoster_with_default_user.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+source dev-container-features-test-lib
+source test_functions.sh
+
+check "configured theme should be agnoster" assert_configured_theme_is "agnoster"
+
+check "configured default user should be vscode" assert_configured_default_user_is "vscode"
+
+reportResults

--- a/test/zsh/using_theme_agnoster_with_no_default_user.sh
+++ b/test/zsh/using_theme_agnoster_with_no_default_user.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+source dev-container-features-test-lib
+source test_functions.sh
+
+check "configured theme should be agnoster" assert_configured_theme_is "agnoster"
+
+check "default user should be empty" assert_configured_default_user_is ""
+
+reportResults

--- a/test/zsh/using_theme_agnoster_with_no_default_user.sh
+++ b/test/zsh/using_theme_agnoster_with_no_default_user.sh
@@ -6,6 +6,6 @@ source test_functions.sh
 
 check "configured theme should be agnoster" assert_configured_theme_is "agnoster"
 
-check "default user should be empty" assert_configured_default_user_is ""
+check "default user should not be set" assert_configured_default_user_is_not_set
 
 reportResults


### PR DESCRIPTION
Fixes #14 

- Adds the `defaultUser` option with a default value of empty
- Writes the `defaultUser` option to the `.zshrc` file
- Adds tests to verify the user is written if specified, or is empty when not specified
- Update the readme to reference the new option

Running `devcontainer features test --feature zsh` passes. For some reason running `devcontainer features test` to run all tests shows a zsh failure at the end but no actual failures in the logs. This reproduces in `main` so I assume it's not something I did.