### PR TITLE
Ability to add the newly created user to specified groups

### DIFF
--- a/src/create-remote-user/devcontainer-feature.json
+++ b/src/create-remote-user/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
   "name": "Create Remote User",
   "id": "create-remote-user",
-  "version": "0.0.4",
-  "description": "A to assert the configured remote user exists in the container",
+  "version": "0.0.5",
+  "description": "A feature to assert the configured remote user exists in the container and optionally add them to additional groups",
   "licenseURL": "https://github.com/nils-geistmann/devcontainers-features/blob/main/LICENSE",
   "options": {
     "create": {
@@ -24,6 +24,11 @@
       "description": "Configures sudo to allow the remote user to elevate permissions without password",
       "type": "boolean",
       "default": false
+    },
+    "additionalGroups": {
+      "description": "Comma-separated list of additional groups to add the user to (e.g., 'audio,video,docker')",
+      "type": "string",
+      "default": ""
     }
   }
 }

--- a/src/create-remote-user/install.sh
+++ b/src/create-remote-user/install.sh
@@ -33,5 +33,9 @@ if [ "$PASSWORDLESSSUDO" = "true" ]; then
   echo "$_REMOTE_USER" ALL=\(root\) NOPASSWD:ALL > "/etc/sudoers.d/$_REMOTE_USER"
 fi
 
+if [ -n "$ADDITIONALGROUPS" ]; then
+  echo "Adding user to additional groups: $ADDITIONALGROUPS"
+  add_user_to_groups "$_REMOTE_USER" "$ADDITIONALGROUPS"
+fi
 
 clean_package_cache

--- a/test/create-remote-user/scenarios.json
+++ b/test/create-remote-user/scenarios.json
@@ -24,5 +24,14 @@
       }
     },
     "remoteUser": "remote"
+  },
+  "with_additional_groups": {
+    "image": "debian:bookworm-slim",
+    "features": {
+      "create-remote-user": {
+        "additionalGroups": "audio,video,plugdev"
+      }
+    },
+    "remoteUser": "remote"
   }
 }

--- a/test/create-remote-user/with_additional_groups.sh
+++ b/test/create-remote-user/with_additional_groups.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+source test_functions.sh
+
+# Test if the user is added to the specified additional groups
+check "user exists" bash -c "id remote"
+check "user in audio group" bash -c "id -nG remote | grep -q audio"
+check "user in video group" bash -c "id -nG remote | grep -q video"
+check "user in plugdev group" bash -c "id -nG remote | grep -q plugdev"
+
+# Verify groups exist first
+check "audio group exists" bash -c "getent group audio"
+check "video group exists" bash -c "getent group video"
+check "plugdev group exists" bash -c "getent group plugdev"
+
+reportResults


### PR DESCRIPTION
For use-cases like audio, device development, etc - we may need to newly created user to be part of certain groups (audio, plugdev, etc.). This PR adds the ability to supply our feature with a comma-separated list of groups to try and add our remote user to.